### PR TITLE
fix: code object for imaginate, sameOrigin support with deepdetect-js v1.7

### DIFF
--- a/code/cpu/config/platform_ui/config.json
+++ b/code/cpu/config/platform_ui/config.json
@@ -23,7 +23,8 @@
         "settings": {
           "path": "/api/deepdetect",
           "isWritable": true,
-          "isHostable": true
+          "isHostable": true,
+          "sameOrigin": true
         }
       }
     ],
@@ -77,35 +78,18 @@
         "best": false,
         "ctc": false,
         "blank_label": false
+      },
+      "code": {
+        "display": {
+          "importLib": true,
+          "ddConfig": true,
+          "postPredict": true,
+          "hostname": null,
+          "port": null
+        }
       }
     },
     "services": [
-      {
-        "name": "testService",
-        "settings": {
-          "display": {
-            "initImages": {},
-            "mode": "description",
-            "okClass": "",
-            "boundingBox": true,
-            "segmentation": false,
-            "separateSegmentation": false,
-            "segmentationColors": ["#1b9e77", "#d95f02"]
-          },
-          "threshold": {
-            "confidence": 0.5,
-            "controls": true,
-            "controlSteps": [0.8, 0.5, 0.3]
-          },
-          "request": {
-            "objSearch": false,
-            "imgSearch": false,
-            "best": false,
-            "ctc": false,
-            "blank_label": false
-          }
-        }
-      }
     ]
   },
   "gpuInfo": {


### PR DESCRIPTION
- commit with `sameOrigin` option in deepdetect-js : https://github.com/jolibrain/deepdetect-js/commit/db603ae43606e2bea45293239aedaefe5ea18867
- remove unused custom `imaginate` config example for `testService`