### PR TITLE
fix: force nginx to resolve dns name every 1s

### DIFF
--- a/code/cpu/config/nginx/nginx.conf
+++ b/code/cpu/config/nginx/nginx.conf
@@ -57,6 +57,15 @@ http {
 
   server {
 
+    # Allow dns resolution at runtime
+    resolver 127.0.0.11 valid=1s ipv6=off;
+
+    # Usage variable force nginx to redo dns resolution every 10s (resolver/valid value)
+    set $dozzle http://dozzle;
+    set $jupyter http://jupyter;
+    set $filebrowser http://filebrowser;
+    set $deepdetect http://deepdetect;
+
     listen 80 default_server;
     listen [::]:80 default_server;
 
@@ -86,7 +95,7 @@ http {
     #
 
     location /code {
-      proxy_pass http://jupyter;
+      proxy_pass $jupyter;
 
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header Host $host;
@@ -94,7 +103,9 @@ http {
     }
 
     location ~* /code/(api/kernels/[^/]+/(channels|iopub|shell|stdin)|terminals/websocket)/? {
-      proxy_pass http://jupyter;
+      rewrite ^/code/(.*) /$1 break;
+
+      proxy_pass $jupyter;
 
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header Host $host;
@@ -110,7 +121,9 @@ http {
     #
 
     location ~ /api/deepdetect/(?<url>.*) {
-      proxy_pass http://deepdetect/$url$is_args$args;
+      proxy_pass $deepdetect/$url$is_args$args;
+      rewrite ^/api/(.*) /$1 break;
+
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection 'upgrade';
@@ -144,7 +157,9 @@ http {
 
       }
 
-      proxy_pass http://filebrowser;
+      proxy_pass $filebrowser;
+      rewrite ^/filebrowser/(.*) /$1 break;
+
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection 'upgrade';
@@ -157,7 +172,8 @@ http {
     #
 
     location /docker-logs {
-      proxy_pass http://dozzle;
+      proxy_pass $dozzle;
+      rewrite ^/docker-logs/(.*) /$1 break;
 
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header Host $host;

--- a/code/gpu/config/nginx/nginx.conf
+++ b/code/gpu/config/nginx/nginx.conf
@@ -62,6 +62,16 @@ http {
 
   server {
 
+    # Allow dns resolution at runtime
+    resolver 127.0.0.11 valid=1s ipv6=off;
+
+    # Usage variable force nginx to redo dns resolution every 10s (resolver/valid value)
+    set $dozzle http://dozzle;
+    set $jupyter http://jupyter;
+    set $filebrowser http://filebrowser;
+    set $deepdetect http://deepdetect;
+    set $gpustat_server http://gpustat_server;
+
     listen 80 default_server;
     listen [::]:80 default_server;
 
@@ -91,7 +101,7 @@ http {
     #
 
     location /code {
-      proxy_pass http://jupyter;
+      proxy_pass $jupyter;
 
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header Host $host;
@@ -99,7 +109,8 @@ http {
     }
 
     location ~* /code/(api/kernels/[^/]+/(channels|iopub|shell|stdin)|terminals/websocket)/? {
-      proxy_pass http://jupyter;
+      rewrite ^/code/(.*) /$1 break;
+      proxy_pass $jupyter;
 
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header Host $host;
@@ -115,7 +126,9 @@ http {
     #
 
     location ~ /api/deepdetect/(?<url>.*) {
-      proxy_pass http://deepdetect/$url$is_args$args;
+      proxy_pass $deepdetect/$url$is_args$args;
+      rewrite ^/api/(.*) /$1 break;
+
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection 'upgrade';
@@ -129,7 +142,8 @@ http {
 
     location ~ /gpu/stats {
       rewrite ^/gpu/stats(.*) /$1  break;
-      proxy_pass http://gpustat_server;
+
+      proxy_pass $gpustat_server;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection 'upgrade';
@@ -162,7 +176,9 @@ http {
 
       }
 
-      proxy_pass http://filebrowser;
+      proxy_pass $filebrowser;
+      rewrite ^/filebrowser/(.*) /$1 break;
+
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection 'upgrade';
@@ -175,7 +191,8 @@ http {
     #
 
     location /docker-logs {
-      proxy_pass http://dozzle;
+      proxy_pass $dozzle;
+      rewrite ^/docker-logs/(.*) /$1 break;
 
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header Host $host;


### PR DESCRIPTION
When a container restart, it's IP change.

Nginx by default does dns resolution only on startup.

So if the IP change, the container is not reachable anymore via nginx.

This change forces nginx to redo dns resolution every 1s.

Fixes #2