### PR TITLE
fix: jupyter container must be root

### DIFF
--- a/code/cpu/docker-compose.yml
+++ b/code/cpu/docker-compose.yml
@@ -53,6 +53,7 @@ services:
 
   jupyter:
     image: jolibrain/jupyter_dd_notebook:${DD_JUPYTER_TAG:-latest}
+    user: root
     environment:
       - JUPYTER_LAB_ENABLE=yes
       - NB_UID=${MUID}

--- a/code/gpu/docker-compose.yml
+++ b/code/gpu/docker-compose.yml
@@ -54,6 +54,7 @@ services:
 
   jupyter:
     image: jolibrain/jupyter_dd_notebook:${DD_JUPYTER_TAG:-latest}
+    user: root
     environment:
       - JUPYTER_LAB_ENABLE=yes
       - NB_UID=${MUID}


### PR DESCRIPTION
To use NB_UID, the container must be ran as root.
So the jupyter startup script can change the uid of the jovyan user and
then su - to this new user.