### PR TITLE
fix: expose .env as /version in platform_ui

### DIFF
--- a/code/cpu/config/nginx/nginx.conf
+++ b/code/cpu/config/nginx/nginx.conf
@@ -194,6 +194,11 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    location /version {
+      # version should not be cached, as it may be updated by docker
+      add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+
   }
 
 }

--- a/code/cpu/docker-compose.yml
+++ b/code/cpu/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - ./config/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ${DD_PLATFORM}:/opt/platform
       - ./config/platform_ui/config.json:/usr/share/nginx/html/config.json
-      - ${DD_PLATFORM}/version.json:/usr/share/nginx/html/version.json
+      - ./.env:/usr/share/nginx/html/version
 
   #
   # Jupyter notebooks

--- a/code/gpu/config/nginx/nginx.conf
+++ b/code/gpu/config/nginx/nginx.conf
@@ -214,6 +214,11 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    location /version {
+      # version should not be cached, as it may be updated by docker
+      add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+
   }
 
 }

--- a/code/gpu/docker-compose.yml
+++ b/code/gpu/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - ./config/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ${DD_PLATFORM}:/opt/platform
       - ./config/platform_ui/config.json:/usr/share/nginx/html/config.json
-      - ${DD_PLATFORM}/version.json:/usr/share/nginx/html/version.json
+      - ./.env:/usr/share/nginx/html/version
 
   #
   # Jupyter notebooks


### PR DESCRIPTION
.env file will be used to displayed the currently running version of platform_ui and notify user about possible update on hub.docker.com