### PR TITLE
fix: fetch docker tags from docker.jolibrain.com

### DIFF
--- a/code/cpu/config/nginx/nginx.conf
+++ b/code/cpu/config/nginx/nginx.conf
@@ -189,7 +189,7 @@ http {
     }
 
     location /docker-tags {
-      proxy_pass https://hub.docker.com/v2/repositories/jolibrain/platform_ui/tags;
+      proxy_pass https://docker.jolibrain.com/v2/platform_ui/tags/list;
       proxy_pass_request_body on;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }

--- a/code/gpu/config/nginx/nginx.conf
+++ b/code/gpu/config/nginx/nginx.conf
@@ -209,7 +209,7 @@ http {
     }
 
     location /docker-tags {
-      proxy_pass https://hub.docker.com/v2/repositories/jolibrain/platform_ui/tags;
+      proxy_pass https://docker.jolibrain.com/v2/platform_ui/tags/list;
       proxy_pass_request_body on;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }


### PR DESCRIPTION
Nginx was fetching platform_ui docker image tags from dockerhub.

Since then, platform_ui docker images have moved to docker.jolibrain.com, changes has been made in nginx configuration in order to change this url.